### PR TITLE
Use home crate to determini cargo home

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 bitcoincore-rpc = "0.13"
 tempfile = "3.1"
 log = "0.4"
-dirs-next = "2.0.0"
+home = "0.5.3"  # use same ver in build-dep
 
 [dev-dependencies]
 env_logger = "0.8"
@@ -22,6 +22,7 @@ ureq = "2.1"
 bitcoin_hashes = "0.9"
 flate2 = "1.0"
 tar = "0.4"
+home = "0.5.3"
 
 [features]
 "0_21_1" = []

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,12 @@ fn main() {
     }
     let download_filename = download_filename();
     let expected_hash = get_expected_sha256(&download_filename).unwrap();
-    let bitcoin_exe_home = format!("{}/bitcoin", std::env::var("CARGO_HOME").unwrap());
+    let bitcoin_exe_home = format!(
+        "{}/bitcoin",
+        home::cargo_home()
+            .expect("cannot determine CARGO_HOME")
+            .display()
+    );
     let existing_filename: PathBuf =
         format!("{}/bitcoin-{}/bin/bitcoind", &bitcoin_exe_home, VERSION).into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,8 +258,8 @@ pub fn downloaded_exe_path() -> Option<String> {
     // CARGO_HOME surely available only in `build.rs` here we need to get from home_dir
     if versions::HAS_FEATURE {
         Some(format!(
-            "{}/.cargo/bitcoin/bitcoin-{}/bin/bitcoind",
-            dirs_next::home_dir()?.display(),
+            "{}/bitcoin/bitcoin-{}/bin/bitcoind",
+            home::cargo_home().ok()?.display(),
             versions::VERSION
         ))
     } else {


### PR DESCRIPTION
According to my understanding of cargo docs $CARGO_HOME should be set up by cargo, but it appears it's not always the case ->  #13 

This uses the suggested `home` crate to determine cargo_home during the build process, since it was used `dirs_next` to do the same things in the binary we used `home` also in the binary so that only one dep is used