### PR TITLE
create wallet and return RPC client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+        if: ${{ matrix.feature != '0_18_1' &&  matrix.feature != '0_18_0' && matrix.feature != '0_17_1' }}
 
   cosmetics:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Adds `create_wallet` creating the node through RPC and returning a connected RPC client