### PR TITLE
Use OUT_DIR when building

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           command: test
           args: --features ${{ matrix.feature }}
-      - run: VERSION_WITH_UNDERSCORE=${{ matrix.feature }} && echo "BITCOIND_EXE=../../../.cargo/bitcoin/bitcoin-${VERSION_WITH_UNDERSCORE//_/.}/bin/bitcoind" >> $GITHUB_ENV
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-        if: ${{ matrix.feature != '0_18_1' &&  matrix.feature != '0_18_0' && matrix.feature != '0_17_1' }}
 
   cosmetics:
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ ureq = "2.1"
 bitcoin_hashes = "0.10"
 flate2 = "1.0"
 tar = "0.4"
-home = "0.5.3"
 
 [features]
 "0_21_1" = []

--- a/Readme.md
+++ b/Readme.md
@@ -22,8 +22,8 @@ assert_eq!(0, bitcoind.client.get_blockchain_info().unwrap().blocks);
 ## Cargo features
 
 When a feature like `0_21_1` is selected, the build script will automatically download the bitcoin core version 0.21.1
-verifying the hashes and placing it in `${CARGO_HOME}`.
-Use utility function `downloaded_exe_path()` to have the downloaded executable path.
+and verify the hashes and place it in the build directory for this crate.
+Use utility function `downloaded_exe_path()` to get the downloaded executable path.
 
 ### Example
 

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use bitcoin_hashes::{sha256, Hash};
 use flate2::read::GzDecoder;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
-use std::path::PathBuf;
+use std::path::Path;
 use std::str::FromStr;
 use tar::Archive;
 
@@ -36,14 +36,15 @@ fn main() {
     }
     let download_filename = download_filename();
     let expected_hash = get_expected_sha256(&download_filename).unwrap();
-    let bitcoin_exe_home = format!(
-        "{}/bitcoin",
-        home::cargo_home()
-            .expect("cannot determine CARGO_HOME")
-            .display()
-    );
-    let existing_filename: PathBuf =
-        format!("{}/bitcoin-{}/bin/bitcoind", &bitcoin_exe_home, VERSION).into();
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    let bitcoin_exe_home = Path::new(&out_dir).join("bitcoin");
+    if !bitcoin_exe_home.exists() {
+        std::fs::create_dir(&bitcoin_exe_home).unwrap();
+    }
+    let existing_filename = bitcoin_exe_home
+        .join(format!("bitcoin-{}", VERSION))
+        .join("bin")
+        .join("bicoind");
 
     if !existing_filename.exists() {
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,11 +279,10 @@ impl From<bitcoincore_rpc::Error> for Error {
 
 /// Provide the bitcoind executable path if a version feature has been specified
 pub fn downloaded_exe_path() -> Option<String> {
-    // CARGO_HOME surely available only in `build.rs` here we need to get from home_dir
     if versions::HAS_FEATURE {
         Some(format!(
             "{}/bitcoin/bitcoin-{}/bin/bitcoind",
-            home::cargo_home().ok()?.display(),
+            env!("OUT_DIR"),
             versions::VERSION
         ))
     } else {


### PR DESCRIPTION
In [build.rs](https://doc.rust-lang.org/cargo/reference/build-scripts.html) you should only ever write to OUT_DIR. Currently we are writing to CARGO_HOME. This is annoying because using cache in CI seems to break this for me because that part of CARGO_HOME is not saved.

Probably same treatment needs to be applied to electrum crate too.