### PR TITLE
Exclude some jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,23 @@ jobs:
         run: cargo fmt -- --check
       - name: clippy
         run: cargo clippy -- -D warnings
+
+  rust-version:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [ "1.41.1", "1.45.0", "1.46.0", "stable", "nightly" ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1.2.0
+        with:
+          key: ${{ matrix.version }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, macos-10.15 ]
+        os: [ ubuntu-20.04 ]
         feature: [ "0_21_1", "0_21_0", "0_20_1", "0_20_0", "0_19_1", "0_19_0_1", "0_18_1", "0_18_0", "0_17_1"]
+        include:
+          - os: "macos-10.15"
+            feature: "0_21_1"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ "1.41.1", "1.45.0", "1.46.0", "stable", "nightly" ]
+        toolchain: [ "1.41.1", "stable", "nightly" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ home = "0.5.3"  # use same ver in build-dep
 env_logger = "0.8"
 
 [build-dependencies]
-ureq = "2.1"
+ureq = "<2"  # allows to keep MSRV 1.41.1
 bitcoin_hashes = "0.10"
 flate2 = "1.0"
 tar = "0.4"

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,10 @@ let bitcoind = bitcoind::BitcoinD::new("/usr/local/bin/bitcoind").unwrap();
 assert_eq!(0, bitcoind.client.get_blockchain_info().unwrap().blocks);
 ```
 
+## MSRV
+
+1.41.1
+
 ## Features
 
   * It waits until bitcoind daemon become ready to accept RPC commands

--- a/build.rs
+++ b/build.rs
@@ -60,7 +60,6 @@ fn main() {
 
         let _size = ureq::get(&url)
             .call()
-            .unwrap()
             .into_reader()
             .read_to_end(&mut downloaded_bytes)
             .unwrap();


### PR DESCRIPTION
on top of #25 

mac os x jobs are more limited than ubuntu's and sometimes there are also timeout issues.
Also, cache size could become too large with many jobs (discarding some cache)

This test all bitcoind version only on ubuntu, while only one bitcoind version is tested on mac