### PR TITLE
Impl `std::Error` for `crate::Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,14 @@ impl fmt::Debug for Error {
     }
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
 const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 
 /// The node configuration parameters, implements a convenient [Default] for most common use.


### PR DESCRIPTION
Making the crate's Error type `std::Error` helps in propagating them easier in downstream application.

Example
```
fn some_func(bitcoind: &electrsd::bitcoind::Bitcoind) -> Result<(), Box<dyn std::error::Error>> {
    ... do something
    bitcoind.client.generate_to_address(101, &core_address)?;
    OK(())
}
```
This will the work.


