### PR TITLE
Update node initiation to handle Persistent DB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: echo "TEMPDIR_ROOT=/dev/shm" >> $GITHUB_ENV
+      #- run: echo "TEMPDIR_ROOT=/dev/shm" >> $GITHUB_ENV # conflicts with test `test_data_persistence`
         if: ${{ matrix.os != 'macos-10.15' }}
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
In usage of recently added #52 , the expected behaviour for `Persistent` type datadir is, the new instance of core will inherent all the existing data. Which is working as expected for other data (blocks, chainstate etc), except the wallet directory. 

The current behavior tries to always create a new `default` wallet at initiation. In case of persistent DB that gives rpc error "wallet file already exists".

This PR updates the init process to handle persistent type database properly..

A test to check the behavior is also added.   