### PR TITLE
feat: Add specific error type for -rpcuser and -rpcpassword usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ tempfile = "3.1"
 log = "0.4"
 home = "0.5.3"  # use same ver in build-dep
 which = "4.2.5"
+regex = "1.6.0"
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ tempfile = "3.1"
 log = "0.4"
 home = "0.5.3"  # use same ver in build-dep
 which = "4.2.5"
-regex = "1.6.0"
 
 [dev-dependencies]
 env_logger = "0.8"


### PR DESCRIPTION
## Description
As discussed in #68 trying to use the `-rpcuser` and `-rpcpassword` leads to an infinite loop, because this authentication method does not work alongside cookie authentication leading to an empty file, and the BitcoinD keeps retrying indefinitely.

This PR adds:
- a new Error variant for this `RpcUserAndPasswordUse`
- a new function to validate the args specified
- two new tests, one for `-rpcuser` and `-rpcpassword` usage, which asserts a failure, and another one for the usage of `-rpcauth` which works fine alongside cookie authentication. 

Fixes #68 