### PR TITLE
CI: update to macos11, test also bitcoind 23.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,12 @@ jobs:
         os: [ ubuntu-20.04 ]
         feature: [ "23_0", "22_0", "0_21_1", "0_21_0", "0_20_1", "0_20_0", "0_19_1", "0_19_0_1", "0_18_1", "0_18_0", "0_17_1"]
         include:
-          - os: "macos-10.15"
+          - os: "macos-11"
             feature: "0_21_1"
+          - os: "macos-11"
+            feature: "22_0"
+          - os: "macos-11"
+            feature: "23_0"
 
     steps:
       - run: df -h

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ include!("src/versions.rs");
 ))]
 fn download_filename() -> String {
     if cfg!(any(
-        feature = "0_22_1",
+        feature = "22_0",
         feature = "0_21_1",
         feature = "0_21_0",
         feature = "0_20_1",


### PR DESCRIPTION
The format of the file names changed in 23.0 (see #71 ) so it makes sense to test also that
version