### PR TITLE
Relax the ureq dependency version requirement to 0.8.1 or greater.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tar = "0.4"
 zip = "0.5"
 
 # allows to keep MSRV 1.41.1
-ureq = "1.0"  
+ureq = "=0.8.1"  
 filetime = "=0.2.15"
 flate2 = "=1.0.22"
 


### PR DESCRIPTION
This is needed in order to be able to use the crate with rocket version 4 (https://github.com/SergioBenitez/Rocket/releases/tag/v0.4.11).