### PR TITLE
Update `ureq` to `2.5.0` and release version 0.28.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           command: test
           args: --features ${{ matrix.feature }}
       - run: echo "BITCOIND_EXE=$(find ./target/debug -name bitcoind)" >> $GITHUB_ENV
-        if: ${{ matrix.os != 'windows-2019' }} 
+        if: ${{ matrix.os != 'windows-2019' }}
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ "1.41.1", "stable", "nightly" ]
+        toolchain: [ "1.56.0", "stable", "nightly" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release 0.28.0
+
+### Changed
+
+- bump `ureq`'s version to `2.5.0`
+- bump `flate2`'s version to `1.0.24`
+- bump `filetime`'s version to `0.2.18`
+
 ## Release 0.27.1
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "bitcoind"
-version = "0.27.1"
+version = "0.28.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest bitcoind process, useful in integration testing environment"
 license = "MIT"
 repository = "https://github.com/RCasatta/bitcoind"
 documentation = "https://docs.rs/bitcoind/"
+rust-version = "1.56"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ bitcoin_hashes = "0.11"
 tar = "0.4"
 zip = "0.5"
 
-# allows to keep MSRV 1.41.1
-ureq = "1.0"  
+ureq = "2.5.0"
 filetime = "=0.2.15"
 flate2 = "=1.0.22"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,11 @@ env_logger = "0.8"
 
 [build-dependencies]
 bitcoin_hashes = "0.11"
+filetime = "0.2"
+flate2 = "1.0"
 tar = "0.4"
-zip = "0.5"
-
 ureq = "2.5.0"
-filetime = "=0.2.15"
-flate2 = "=1.0.22"
+zip = "0.5"
 
 [features]
 "23_0" = []

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ assert_eq!(0, bitcoind.client.get_blockchain_info().unwrap().blocks);
 When a feature like `22_0` is selected, the build script will automatically download the bitcoin core version `22.0`, verify the hashes and place it in the build directory for this crate.
 Use utility function `downloaded_exe_path()` to get the downloaded executable path.
 
-### Example 
+### Example
 
 In your project Cargo.toml, activate the following features
 
@@ -35,7 +35,7 @@ let bitcoind = bitcoind::BitcoinD::new(bitcoind::downloaded_exe_path().unwrap())
 
 ## MSRV
 
-1.41.1
+1.53
 
 ## Issues with traditional approach
 
@@ -50,7 +50,7 @@ I used integration testing based on external bash script launching needed extern
 
   * It waits until bitcoind daemon become ready to accept RPC commands
   * bitcoind use a temporary directory as datadir. You can specify the root of your temp directories so that you have node's datadir in a RAM disk (eg `/dev/shm`)
-  * Free ports are asked to the OS (a low probability race condition is still possible) 
+  * Free ports are asked to the OS (a low probability race condition is still possible)
   * the process is killed when the struct goes out of scope no matter how the test finishes
   * allows easy spawning of dependent process like https://github.com/RCasatta/electrsd
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let bitcoind = bitcoind::BitcoinD::new(bitcoind::downloaded_exe_path().unwrap())
 
 ## MSRV
 
-1.53
+The MSRV is 1.41 for versions up to 0.27.\*, and 1.56 from 0.28.0.
 
 ## Issues with traditional approach
 

--- a/build.rs
+++ b/build.rs
@@ -103,7 +103,7 @@ fn main() {
         );
         println!("url:{}", url);
         let mut downloaded_bytes = Vec::new();
-        let resp = ureq::get(&url).call();
+        let resp = ureq::get(&url).call().unwrap();
         assert_eq!(resp.status(), 200, "url {} didn't return 200", url);
 
         let _size = resp


### PR DESCRIPTION
This forces a jump in MSRV. I've set the new MSRV to 1.53 since that seems to be what [`ureq`'s MSRV is](https://github.com/algesten/ureq/issues/543).