### PR TITLE
Use reqwest instead of ureq for download

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bitcoin_hashes = "0.11"
 filetime = "0.2"
 flate2 = "1.0"
 tar = "0.4"
-ureq = "2.5.0"
+reqwest = { version = "0.10", features = ["blocking"] }
 zip = "0.6"
 time = "=0.3.10"  # otherwise rust 1.57 fails to select time "^0.3.7"
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use bitcoin_hashes::{sha256, Hash};
 use flate2::read::GzDecoder;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Cursor, Read};
+use std::io::{self, BufRead, BufReader, Cursor};
 use std::path::Path;
 use std::str::FromStr;
 use tar::Archive;
@@ -103,13 +103,11 @@ fn main() {
         );
         println!("url:{}", url);
         let mut downloaded_bytes = Vec::new();
-        let resp = ureq::get(&url).call().unwrap();
+        let mut resp =
+            reqwest::blocking::get(&url).expect(&format!("fetched bitcoin core from {}", url));
         assert_eq!(resp.status(), 200, "url {} didn't return 200", url);
+        let _size = resp.copy_to(&mut downloaded_bytes).unwrap();
 
-        let _size = resp
-            .into_reader()
-            .read_to_end(&mut downloaded_bytes)
-            .unwrap();
         let downloaded_hash = sha256::Hash::hash(&downloaded_bytes);
         assert_eq!(expected_hash, downloaded_hash);
 


### PR DESCRIPTION
Attempt at resolving MSRV issues caused by `ureq`: https://github.com/RCasatta/bitcoind/issues/95

I believe this `reqwest` version 0.10 [has MSRV 1.39.0](https://github.com/seanmonstar/reqwest/blob/0.10.x/.github/workflows/ci.yml#L194) 