### PR TITLE
Make download endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Then use it:
 let bitcoind = bitcoind::BitcoinD::new(bitcoind::downloaded_exe_path().unwrap()).unwrap();
 ```
 
+When the `BITCOIND_DOWNLOAD_ENDPOINT` environment variable is set, `bitcoind` will try to download the biniaries from the given endpoint. Otherwise it defaults to `https://bitcoincore.org/bin/`.
+
 ## MSRV
 
 The MSRV is 1.41.1 for version 0.29.* if no feature is used, otherwise is 1.57

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then use it:
 let bitcoind = bitcoind::BitcoinD::new(bitcoind::downloaded_exe_path().unwrap()).unwrap();
 ```
 
-When the `BITCOIND_DOWNLOAD_ENDPOINT` environment variable is set, `bitcoind` will try to download the biniaries from the given endpoint. Otherwise it defaults to `https://bitcoincore.org/bin/`.
+When the `BITCOIND_DOWNLOAD_ENDPOINT` environment variable is set, `bitcoind` will try to download the binaries from the given endpoint. Otherwise it defaults to `https://bitcoincore.org/bin/`.
 
 ## MSRV
 

--- a/build.rs
+++ b/build.rs
@@ -108,9 +108,12 @@ mod download {
                 download_filename, VERSION, expected_hash
             );
 
+            let download_endpoint = std::env::var("BITCOIND_DOWNLOAD_ENDPOINT")
+                .unwrap_or("https://bitcoincore.org/bin/".to_owned());
+
             let url = format!(
-                "https://bitcoincore.org/bin/bitcoin-core-{}/{}",
-                VERSION, download_filename
+                "{}/bitcoin-core-{}/{}",
+                download_endpoint, VERSION, download_filename
             );
             println!("url:{}", url);
             let mut downloaded_bytes = Vec::new();


### PR DESCRIPTION
Closes #106.

In this PR we make the download endpoint configurable. If this is accepted, I'll see to open an equivalent PR towards `electrsd`.