### PR TITLE
Replace `ureq` with `minreq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ env_logger = "0.9.0"
 bitcoin_hashes = { version = "0.11", optional = true }
 flate2 = { version = "1.0", optional = true } 
 tar = { version = "0.4", optional = true } 
-ureq = { version = "2.5.0", optional = true }
+minreq = { version = "2.6.0", default-features = false, features = ["https"], optional = true }
 zip = { version = "0.6", optional = true }
 
 [features]
-"download" = ["bitcoin_hashes", "flate2", "tar", "ureq", "zip"]
+"download" = ["bitcoin_hashes", "flate2", "tar", "minreq", "zip"]
 "23_0" = ["download"]
 "22_0" = ["download"]
 "0_21_1" = ["download"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Utility to run a regtest bitcoind process, useful in integration testing environ
 
 ```rust
 use bitcoincore_rpc::RpcApi;
-let exe_path = exe_path().expect("bitcoind executable must be provided in BITCOIND_EXE, or with a feature like '22_0', or be in PATH");
+let exe_path = exe_path().expect("bitcoind executable must be provided in BITCOIND_EXE, or with a feature like '23_0', or be in PATH");
 let bitcoind = bitcoind::BitcoinD::new(exe_path).unwrap();
 assert_eq!(0, bitcoind.client.get_blockchain_info().unwrap().blocks);
 ```
 
 ## Automatic binaries download
 
-When a feature like `22_0` is selected, the build script will automatically download the bitcoin core version `22.0`, verify the hashes and place it in the build directory for this crate.
+When a feature like `23_0` is selected, the build script will automatically download the bitcoin core version `23.0`, verify the hashes and place it in the build directory for this crate.
 Use utility function `downloaded_exe_path()` to get the downloaded executable path.
 
 ### Example
@@ -24,7 +24,7 @@ In your project Cargo.toml, activate the following features
 ```toml
 
 [dev-dependencies]
-bitcoind = { version = "0.20.0", features = [ "22_0" ] }
+bitcoind = { version = "0.20.0", features = [ "23_0" ] }
 ```
 
 Then use it:

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ mod download {
     use bitcoin_hashes::{sha256, Hash};
     use flate2::read::GzDecoder;
     use std::fs::File;
-    use std::io::{self, BufRead, BufReader, Cursor, Read};
+    use std::io::{self, BufRead, BufReader, Cursor};
     use std::path::Path;
     use std::str::FromStr;
     use tar::Archive;
@@ -116,14 +116,10 @@ mod download {
                 download_endpoint, VERSION, download_filename
             );
             println!("url:{}", url);
-            let mut downloaded_bytes = Vec::new();
-            let resp = ureq::get(&url).call().unwrap();
-            assert_eq!(resp.status(), 200, "url {} didn't return 200", url);
+            let resp = minreq::get(&url).send().unwrap();
+            assert_eq!(resp.status_code, 200, "url {} didn't return 200", url);
 
-            let _size = resp
-                .into_reader()
-                .read_to_end(&mut downloaded_bytes)
-                .unwrap();
+            let downloaded_bytes = resp.as_bytes();
             let downloaded_hash = sha256::Hash::hash(&downloaded_bytes);
             assert_eq!(expected_hash, downloaded_hash);
 


### PR DESCRIPTION
Multiple projects in the `rust-bitcoin` space are currently planning a migration away from `ureq` to `minreq`, as it provides better MSRV guarantees.

In this PR we trivially replace the `ureq` dependency by `minreq`. Note that this doesn't necessarily lower the MSRV right away due to the included `rustls` dependency, but is a preparatory step.

Also see https://github.com/RCasatta/electrsd/pull/58.