### PR TITLE
conditionally include doc include

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(missing_docs)]
-
-//! See [Readme](https://github.com/RCasatta/bitcoind/blob/master/README.md)
-//!
-//! when MSRV will reach 1.54 `#![doc = include_str!("../README.md")]`
+#![cfg_attr(feature = "doc", cfg_attr(all(), doc = include_str!("../README.md")))]
 
 mod versions;
 


### PR DESCRIPTION
This allows to generate doc including the readme in the crate level doc, while not breaking the build in rust 1.41.1