### PR TITLE
make every version imply the one before it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,16 @@ zip = { version = "0.5", optional = true }
 # download is not supposed to be used directly only through selecting one of the version feature
 "download" = ["bitcoin_hashes", "flate2", "tar", "minreq", "zip"]
 
-"23_0" = ["download"]
-"22_0" = ["download"]
-"0_21_1" = ["download"]
-"0_21_0" = ["download"]
-"0_20_1" = ["download"]
-"0_20_0" = ["download"]
-"0_19_1" = ["download"]
-"0_19_0_1" = ["download"]
-"0_18_1" = ["download"]
-"0_18_0" = ["download"]
+"23_0" = ["download", "22_0"]
+"22_0" = ["download", "0_21_1"]
+"0_21_1" = ["download", "0_21_0"]
+"0_21_0" = ["download", "0_20_1"]
+"0_20_1" = ["download", "0_20_0"]
+"0_20_0" = ["download", "0_19_1"]
+"0_19_1" = ["download", "0_19_0_1"]
+"0_19_0_1" = ["download", "0_18_1"]
+"0_18_1" = ["download", "0_18_0"]
+"0_18_0" = ["download", "0_17_1"]
 "0_17_1" = ["download"]
 
 "doc" = [] # used only for documentation building

--- a/build.rs
+++ b/build.rs
@@ -27,18 +27,7 @@ mod download {
         any(target_arch = "x86_64", target_arch = "aarch64"),
     ))]
     fn download_filename() -> String {
-        if cfg!(any(
-            feature = "22_0",
-            feature = "0_21_1",
-            feature = "0_21_0",
-            feature = "0_20_1",
-            feature = "0_20_0",
-            feature = "0_19_1",
-            feature = "0_19_0_1",
-            feature = "0_18_1",
-            feature = "0_18_0",
-            feature = "0_17_1",
-        )) {
+        if cfg!(not(feature = "23_0")) {
             format!("bitcoin-{}-osx64.tar.gz", &VERSION)
         } else {
             format!("bitcoin-{}-x86_64-apple-darwin.tar.gz", &VERSION)
@@ -62,17 +51,7 @@ mod download {
 
     fn get_expected_sha256(filename: &str) -> sha256::Hash {
         let sha256sums_filename = format!("sha256/bitcoin-core-{}-SHA256SUMS", &VERSION);
-        #[cfg(any(
-            feature = "0_21_1",
-            feature = "0_21_0",
-            feature = "0_20_1",
-            feature = "0_20_0",
-            feature = "0_19_1",
-            feature = "0_19_0_1",
-            feature = "0_18_1",
-            feature = "0_18_0",
-            feature = "0_17_1",
-        ))]
+        #[cfg(not(feature = "22_0"))]
         let sha256sums_filename = format!("{}.asc", sha256sums_filename);
         let file = File::open(&sha256sums_filename).unwrap();
         for line in BufReader::new(file).lines().flatten() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ impl BitcoinD {
         format!("http://{}", self.params.rpc_socket)
     }
 
-    #[cfg(not(any(feature = "0_17_1", feature = "0_18_0", feature = "0_18_1")))]
+    #[cfg(any(feature = "0_19_0_1", not(feature = "download")))]
     /// Returns the rpc URL including the schema and the given `wallet_name`
     /// eg. http://127.0.0.1:44842/wallet/my_wallet
     pub fn rpc_url_with_wallet<T: AsRef<str>>(&self, wallet_name: T) -> String {
@@ -397,7 +397,7 @@ impl BitcoinD {
         Ok(self.process.wait()?)
     }
 
-    #[cfg(not(any(feature = "0_17_1", feature = "0_18_0", feature = "0_18_1")))]
+    #[cfg(any(feature = "0_19_0_1", not(feature = "download")))]
     /// Create a new wallet in the running node, and return an RPC client connected to the just
     /// created wallet
     pub fn create_wallet<T: AsRef<str>>(&self, wallet: T) -> anyhow::Result<Client> {
@@ -545,7 +545,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(feature = "0_21_0", feature = "0_21_1"))]
+    #[cfg(feature = "0_21_0")]
     fn test_getindexinfo() {
         let exe = init();
         let mut conf = Conf::default();
@@ -639,7 +639,7 @@ mod test {
         assert_eq!(node3_peers, 1, "listen false but more than 1 peer");
     }
 
-    #[cfg(not(any(feature = "0_17_1", feature = "0_18_0", feature = "0_18_1")))]
+    #[cfg(any(feature = "0_19_0_1", not(feature = "download")))]
     #[test]
     fn test_multi_wallet() {
         use bitcoincore_rpc::bitcoin::Amount;

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,47 +1,35 @@
-#[cfg(not(any(
-    feature = "23_0",
-    feature = "22_0",
-    feature = "0_21_1",
-    feature = "0_21_0",
-    feature = "0_20_1",
-    feature = "0_20_0",
-    feature = "0_19_1",
-    feature = "0_19_0_1",
-    feature = "0_18_1",
-    feature = "0_18_0",
-    feature = "0_17_1",
-)))]
-pub const VERSION: &str = "N/A";
-
 #[cfg(feature = "23_0")]
 pub const VERSION: &str = "23.0";
 
-#[cfg(feature = "22_0")]
+#[cfg(all(feature = "22_0", not(feature = "23_0")))]
 pub const VERSION: &str = "22.0";
 
-#[cfg(feature = "0_21_1")]
+#[cfg(all(feature = "0_21_1", not(feature = "22_0")))]
 pub const VERSION: &str = "0.21.1";
 
-#[cfg(feature = "0_21_0")]
+#[cfg(all(feature = "0_21_0", not(feature = "0_21_1")))]
 pub const VERSION: &str = "0.21.0";
 
-#[cfg(feature = "0_20_1")]
+#[cfg(all(feature = "0_20_1", not(feature = "0_21_0")))]
 pub const VERSION: &str = "0.20.1";
 
-#[cfg(feature = "0_20_0")]
+#[cfg(all(feature = "0_20_0", not(feature = "0_20_1")))]
 pub const VERSION: &str = "0.20.0";
 
-#[cfg(feature = "0_19_1")]
+#[cfg(all(feature = "0_19_1", not(feature = "0_20_0")))]
 pub const VERSION: &str = "0.19.1";
 
-#[cfg(feature = "0_19_0_1")]
+#[cfg(all(feature = "0_19_0_1", not(feature = "0_19_1")))]
 pub const VERSION: &str = "0.19.0.1";
 
-#[cfg(feature = "0_18_1")]
+#[cfg(all(feature = "0_18_1", not(feature = "0_19_0_1")))]
 pub const VERSION: &str = "0.18.1";
 
-#[cfg(feature = "0_18_0")]
+#[cfg(all(feature = "0_18_0", not(feature = "0_18_1")))]
 pub const VERSION: &str = "0.18.0";
 
-#[cfg(feature = "0_17_1")]
+#[cfg(all(feature = "0_17_1", not(feature = "0_18_0")))]
 pub const VERSION: &str = "0.17.1";
+
+#[cfg(not(feature = "0_17_1"))]
+pub const VERSION: &str = "N/A";


### PR DESCRIPTION
This allows the library to be compiled with any combination of versions of Bitcoin Core -- it will just use the highest one.

This won't guarantee compatibility because Bitcoin Core sometimes makes backward-compatibility breaking changes ... but it is much better than the current situation where if you specify multiple feature flags, the library won't compile at all.