### PR TITLE
ci: add job to run cargo audit on pull_request and weekly

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Audit
+
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 0 * * 0' # Once per week
+
+jobs:
+
+  security_audit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,14 +69,15 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: |
+          cargo update
           cargo update -p which --precise 4.2.5
           cargo update -p tempfile --precise 3.3.0
           cargo update -p log --precise 0.4.18
           cargo update -p serde_json --precise 1.0.99
           cargo update -p serde --precise 1.0.156
           cargo update -p regex --precise 1.7.3
-          cargo update -p thiserror --precise 1.0.40
           cargo update -p quote --precise 1.0.28
+          cargo update -p syn:2.0.37 --precise 2.0.32
           cargo update -p proc-macro2 --precise 1.0.63
         if: ${{ matrix.toolchain == '1.48.0' }}
       - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tar = { version = "0.4", optional = true }
 minreq = { version = "2.9.1", default-features = false, features = [
     "https",
 ], optional = true }
-zip = { version = "0.5", optional = true }
+zip = { version = "0.6", optional = true }
 anyhow = "1.0.66"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -78,12 +78,21 @@ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features download,doc --open
 
 The MSRV is 1.48.0 for version 0.29.* if no feature is used, otherwise is 1.57
 
-Note: to respect 1.48.0 MSRV you need to use and older version of the which and tempfile dependencies, 
-like it's done in the CI:
+Note: to respect 1.48.0 MSRV you need to use and older version of some dependencies, in CI the below
+dependency versions are pinned:
 
 ```sh
-cargo update -p serde --precise 1.0.152
+cargo update
+cargo update -p which --precise 4.2.5
+cargo update -p tempfile --precise 3.3.0
 cargo update -p log --precise 0.4.18
+cargo update -p serde_json --precise 1.0.99
+cargo update -p serde --precise 1.0.156
+cargo update -p regex --precise 1.7.3
+cargo update -p thiserror --precise 1.0.40
+cargo update -p quote --precise 1.0.28
+cargo update -p syn:2.0.37 --precise 2.0.32
+cargo update -p proc-macro2 --precise 1.0.63
 ```
 
 Pinning in `Cargo.toml` is avoided because it could cause


### PR DESCRIPTION
Fixes #92 

Added the `audit.yml` workflow file from the `bdk` project. I also had to fix [RUSTSEC-2020-0071] by updating the `zip` dependency to 0.6 and I had to update some MSRV pinning in the CI workflow and README instructions.

I ran into the audit issue when adding `bitcoind` to `bdk` for some new integration tests. Once this is merged can you publish a new patch release?

[RUSTSEC-2020-0071]: https://rustsec.org/advisories/RUSTSEC-2020-0071