### PR TITLE
Upgrade bitcoincore-rpc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-bitcoincore-rpc = { version = "0.17.0" }
+bitcoincore-rpc = { git = "https://github.com/tcharding/rust-bitcoincore-rpc.git", branch = "10-16-upgrade-bitcoin" }
 log = "0.4"
 which = "4.2.5"
 anyhow = "1.0.66"
@@ -21,7 +21,7 @@ tempfile = "3"
 env_logger = "0.9.0"
 
 [build-dependencies]
-bitcoin_hashes = { version = "0.12", optional = true }
+bitcoin_hashes = { version = "0.13", optional = true }
 flate2 = { version = "1.0", optional = true }
 tar = { version = "0.4", optional = true }
 minreq = { version = "2.9.1", default-features = false, features = [


### PR DESCRIPTION
This PR is basically just noise, really only useful only to highlight the `rust-bitcoincore-rcp` branch with the upgrade on it case you want to use it locally.

ref: https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/311 

No changes required to this crate, done while attempting to upgrade to `rust-bitcoin v0.31.0-rc1` in `miniscript` and `bdk`.